### PR TITLE
Allow passing fmt arguments

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v1.4.0
+    rev: v3.1.0
     hooks:
     -   id: check-byte-order-marker
     -   id: check-case-conflict
@@ -11,6 +11,6 @@ repos:
     -   id: mixed-line-ending
     -   id: trailing-whitespace
 -   repo: https://github.com/pre-commit/pre-commit
-    rev: v1.10.4
+    rev: v2.5.1
     hooks:
     -   id: validate_manifest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
--   repo: git://github.com/pre-commit/pre-commit-hooks
+-   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v3.1.0
     hooks:
     -   id: check-byte-order-marker

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,7 +4,7 @@
     entry: cargo fmt
     language: system
     types: [rust]
-    pass_filenames: false
+    args: ['--']
 -   id: cargo-check
     name: cargo check
     description: Check the package for errors.

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,10 +1,10 @@
 -   id: fmt
     name: fmt
     description: Format files with cargo fmt.
-    entry: cargo fmt --
+    entry: cargo fmt
     language: system
     types: [rust]
-    args: []
+    pass_filenames: false
 -   id: cargo-check
     name: cargo check
     description: Check the package for errors.

--- a/README.md
+++ b/README.md
@@ -11,3 +11,13 @@
     -   id: fmt
     -   id: cargo-check
 ```
+
+## Passing arguments to rustfmt
+
+```yaml
+-   repo: https://github.com/doublify/pre-commit-rust
+    rev: master
+    hooks:
+    -   id: fmt
+        args: ['--verbose', '--edition', '2018', '--']
+```


### PR DESCRIPTION
Closes #7 and #8 

To maintain the previous behaviour of formatting the files added and not necessarily used (`cargo fmt` won't format modules that are not used) there is a catch that if someone wants to pass arguments, one also has to add `'--'` at the very end, like so:
```
args: ['--manifest-path', 'my-project/Cargo.toml', '--']
```