### PR TITLE
Automatically tag every commit to 'master'

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - id: compute_tag
+        uses: craig-day/compute-tag@v10
+        with:
+          github_token: ${{ github.token }}
+          version_scheme: continuous
+          version_type: major
+
+      - name: create release
+        uses: actions/create-release@v1
+        with:
+          tag_name: ${{ steps.compute_tag.outputs.next_tag }}
+          release_name: ${{ steps.compute_tag.outputs.next_tag }}
+          body: >
+            Automatic release of ${{ steps.compute_tag.outputs.next_tag }}
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+


### PR DESCRIPTION
Use Github workflow to tag every commit to master. Tags follow the format v1, v2, v3, etc. This would make it friendlier to pin to a specific commit without any need to think about what's a "release" of the commit-hook.

I have not tested this but it should Just Work.

fixes #3