### PR TITLE
Enabling possibility to add custom arguments to clippy too.

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,21 +1,22 @@
--   id: fmt
-    name: fmt
-    description: Format files with cargo fmt.
-    entry: cargo fmt
-    language: system
-    types: [rust]
-    args: ['--']
--   id: cargo-check
-    name: cargo check
-    description: Check the package for errors.
-    entry: cargo check
-    language: system
-    types: [rust]
-    pass_filenames: false
--   id: clippy
-    name: clippy
-    description: Lint rust sources
-    entry: cargo clippy -- -D warnings
-    language: system
-    types: [rust]
-    pass_filenames: false
+- id: fmt
+  name: fmt
+  description: Format files with cargo fmt.
+  entry: cargo fmt
+  language: system
+  types: [rust]
+  args: ["--"]
+- id: cargo-check
+  name: cargo check
+  description: Check the package for errors.
+  entry: cargo check
+  language: system
+  types: [rust]
+  pass_filenames: false
+- id: clippy
+  name: clippy
+  description: Lint rust sources
+  entry: cargo clippy
+  language: system
+  args: ["--", "-D", "warnings"]
+  types: [rust]
+  pass_filenames: false


### PR DESCRIPTION
As per https://github.com/doublify/pre-commit-rust/issues/8#issuecomment-663443021 the clippy hook was not up-to-date to be able to customize arguments to specify a Cargo.toml file. This should be the case now.

Should I update the README as the default arg for clippy is different ?