### PR TITLE
cargo clean before clippy or it may not work.

### DIFF
--- a/hooks.yaml
+++ b/hooks.yaml
@@ -15,7 +15,7 @@
 -   id: cargo-clippy
     name: cargo clippy
     description: Run the Clippy linter on the package.
-    entry: cargo clippy -- -D warnings
+    entry: cargo clean && cargo clippy -- -D warnings
     language: system
     files: \.rs$
     pass_filenames: false


### PR DESCRIPTION
https://github.com/rust-lang/rust-clippy/issues/1495 and https://github.com/rust-lang/rust-clippy/issues/4612 for details.

In short, clippy is not guaranteed to output results unless a few conditions are satisfied. The easiest of which is running `cargo clean` before clippy. 

There are alternatives that may be preferable for performance, but I suggest this for a simple, easy first pass.