### PR TITLE
add cargo docs hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -12,6 +12,13 @@
   language: system
   types: [rust]
   pass_filenames: false
+- id: cargo-doc
+  name: cargo doc
+  description: Build package docs.
+  entry: cargo doc
+  language: system
+  types: [rust]
+  pass_filenames: false
 - id: clippy
   name: clippy
   description: Lint rust sources

--- a/hooks.yaml
+++ b/hooks.yaml
@@ -12,6 +12,13 @@
     language: system
     files: \.rs$
     pass_filenames: false
+-   id: cargo-docs
+    name: cargo docs
+    description: Build docs for the package.
+    entry: cargo doc
+    language: system
+    files: \.rs$
+    pass_filenames: false
 -   id: cargo-clippy
     name: cargo clippy
     description: Run the Clippy linter on the package.


### PR DESCRIPTION
Hello and thank you for this library!

I wanted a hook that automatically built the docs every time that I updated any rust code in my repo and thought that it might be a useful addition to this library. I used it in a private repo, and it generates the static site in `target/doc` directory as described in the [rustdoc section](https://doc.rust-lang.org/rustdoc/index.html) of the book.

If this PR isn't useful feel free to delete it, and thanks again for the library!