### PR TITLE
Fix readme for rusftmt args

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,5 +19,7 @@
     rev: master
     hooks:
     -   id: fmt
-        args: ['--verbose', '--edition', '2018', '--']
+        args: ['--verbose', '--', '--edition', '2018' ]
 ```
+
+Note: Cargo fmt picks up "edition" automatically from Cargo.toml, so specificying this isn't necessary in most cases.


### PR DESCRIPTION
The double dash needs to come before rustfmt args. Also, specifying it when Cargo.toml already specifies the edition will result in a warning.