### PR TITLE
docs: add clippy hook to example

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.1.0
+    rev: v4.5.0
     hooks:
     -   id: check-byte-order-marker
     -   id: check-case-conflict
@@ -11,6 +11,6 @@ repos:
     -   id: mixed-line-ending
     -   id: trailing-whitespace
 -   repo: https://github.com/pre-commit/pre-commit
-    rev: v2.5.1
+    rev: v3.6.2
     hooks:
     -   id: validate_manifest

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -26,7 +26,8 @@
   entry: cargo test
   language: system
   types: [rust]
-  args: ["--all-targets", "--", "--nocapture", "--test-threads=1", "--test"]
+  args: ["--all-targets"]
+  pass_filenames: false
 - id: build
   name: build
   description: Build using cargo build

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -20,3 +20,17 @@
   args: ["--", "-D", "warnings"]
   types: [rust]
   pass_filenames: false
+- id: test
+  name: test
+  description: Run tests with cargo test
+  entry: cargo test
+  language: system
+  types: [rust]
+  args: ["--all-targets", "--", "--nocapture", "--test-threads=1", "--test"]
+- id: build
+  name: build
+  description: Build using cargo build
+  language: system
+  types: ["rust"]
+  entry: cargo build
+  pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
     hooks:
     -   id: fmt
     -   id: cargo-check
+    -   id: cargo-clippy
 ```
 
 ## Passing arguments to rustfmt

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
     hooks:
     -   id: fmt
     -   id: cargo-check
-    -   id: cargo-clippy
+    -   id: clippy
 ```
 
 ## Passing arguments to rustfmt

--- a/README.md
+++ b/README.md
@@ -2,23 +2,27 @@
 
 [Rust](https://www.rust-lang.org) tools package for [pre-commit](https://pre-commit.com).
 
+Forked from: [doublify's pre-commit-rust](https://github.com/doublify/pre-commit-rust) (**NOTE: Their repo is unmaintained**)
+
 ## Using rust tools with pre-commit
 
 ```yaml
--   repo: https://github.com/doublify/pre-commit-rust
+-   repo: https://github.com/antonio-hickey/rusted-pre-commits
     rev: master
     hooks:
     -   id: fmt
     -   id: cargo-check
     -   id: clippy
+    -   id: build
+    -   id: test
 ```
 
 ## Passing arguments to rustfmt
 
 ```yaml
--   repo: https://github.com/doublify/pre-commit-rust
+-   repo: https://github.com/antonio-hickey/rusted-pre-commits
     rev: master
     hooks:
     -   id: fmt
-        args: ['--verbose', '--edition', '2018', '--']
+        args: ['--verbose', '--edition', '2021', '--']
 ```

--- a/hooks.yaml
+++ b/hooks.yaml
@@ -1,7 +1,7 @@
 -   id: fmt
     name: fmt
     description: Format files with cargo fmt.
-    entry: cargo fmt --
+    entry: cargo fmt
     language: system
     files: \.rs$
     args: []

--- a/hooks.yaml
+++ b/hooks.yaml
@@ -2,20 +2,20 @@
     name: fmt
     description: Format files with cargo fmt.
     entry: cargo fmt
-    language: system
+    language: rust
     files: \.rs$
     args: []
 -   id: cargo-check
     name: cargo check
     description: Check the package for errors.
     entry: cargo check
-    language: system
+    language: rust
     files: \.rs$
     pass_filenames: false
 -   id: cargo-clippy
     name: cargo clippy
     description: Run the Clippy linter on the package.
     entry: cargo clippy -- -D warnings
-    language: system
+    language: rust
     files: \.rs$
     pass_filenames: false


### PR DESCRIPTION
Makes it easier for the user to know how to set up all the hooks available.