### PR TITLE
docs: Modify example rev to `v1.0`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ```yaml
 -   repo: https://github.com/doublify/pre-commit-rust
-    rev: master
+    rev: v1.0
     hooks:
     -   id: fmt
     -   id: cargo-check
@@ -16,7 +16,7 @@
 
 ```yaml
 -   repo: https://github.com/doublify/pre-commit-rust
-    rev: master
+    rev: v1.0
     hooks:
     -   id: fmt
         args: ['--verbose', '--edition', '2018', '--']


### PR DESCRIPTION
## Overview
Changed the value of _**rev**_ in the example code listed in `README.md` from `master` to `v1.0`.

## Why
Because the following warnings occur.

> [WARNING] The 'rev' field of repo 'https://github.com/doublify/pre-commit-rust' appears to be a mutable reference (moving tag / branch).  Mutable references are never updated after first install and are not supported.  See https://pre-commit.com/#using-the-latest-version-for-a-repository for more details.  Hint: `pre-commit autoupdate` often fixes this.