### PR TITLE
Update name for fmt hook

### DIFF
--- a/hooks.yaml
+++ b/hooks.yaml
@@ -1,5 +1,5 @@
 -   id: fmt
-    name: fmt
+    name: cargo fmt
     description: Format files with cargo fmt.
     entry: cargo fmt --
     language: system


### PR DESCRIPTION
Is now more consistent with the name for other hooks.