### PR TITLE
Fix possible file corruptions via fmt hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -5,6 +5,7 @@
   language: system
   types: [rust]
   args: ["--"]
+  pass_filenames: false
 - id: cargo-check
   name: cargo check
   description: Check the package for errors.


### PR DESCRIPTION
rustfmt should not be called on multiple files, since it can update included files as well, which will lead to writing different files without a lock, and inevitably will corrupt them.